### PR TITLE
Simplify UUID regex for better performance

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -340,7 +340,10 @@ def _cleanup(rows: List[List[str]], root: Path, apply: bool) -> None:
     def check_one(p: Path):
         try:
             data = p.read_text(encoding="utf-8", errors="ignore").strip()
-            m = re.search(r"/proxy/vod/(movie|episode)/([a-f0-9\-]{16,})", data, flags=re.I)
+            # Simple UUID extraction pattern: [a-f0-9-]+
+            # We control .strm generation, so UUIDs are always valid UUID v4 format.
+            # No need for strict validation - simpler pattern = faster when scanning 1000s of files.
+            m = re.search(r"/proxy/vod/(movie|episode)/([a-f0-9-]+)", data, flags=re.I)
             if not m:
                 return ("unknown", None)
             typ, uid = m.group(1).lower(), m.group(2)


### PR DESCRIPTION
## Changes
- Change from `[a-f0-9\-]{16,}` to simpler `[a-f0-9-]+`
- Faster execution when scanning thousands of files during cleanup
- Add detailed comment explaining why simple pattern is sufficient

## Why
We control .strm file generation, so UUIDs are always valid UUID v4 format. No need for strict validation regex - simpler pattern is faster when scanning 1000s of files during cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation pattern to handle a wider range of identifier formats while maintaining security through upstream verification.

* **Performance**
  * Optimized identifier validation for faster processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->