### PR TITLE
Version 0.0.2 - Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Adaptive throttle: NAS slow (avg 0.350s), reducing workers 4 → 3
 ## Versioning
 
 Semantic versioning: `MAJOR.MINOR.PATCH`
-- Current: `0.0.1`
-- Increments: `0.0.2`, `0.0.3`, etc.
+- Current: `0.0.2`
+- Increments: `0.0.3`, `0.0.4`, etc.
 
 ## License
 

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,6 @@
 """
 vod2strm – Dispatcharr Plugin
-Version: 0.0.1
+Version: 0.0.2
 
 Spec:
 - ORM (in-process) with Celery background tasks (non-blocking UI).
@@ -9,7 +9,7 @@ Spec:
   * Movies -> <root>/Movies/{Name} ({Year})/{Name} ({Year}).strm
   * Series -> <root>/TV/{SeriesName (Year) or SeriesName + (year)}/Season {SS or 00}/S{SS}E{EE} - {Title}.strm
   * Season 00 labeled "Season 00 (Specials)".
-  * .strm contents use {base_url}/proxy/vod/(movies|episodes)/{uuid}
+  * .strm contents use {base_url}/proxy/vod/(movie|episode)/{uuid}
 - NFO generation (compare-before-write):
   * Movies: movie.nfo in movie folder
   * Seasons: season.nfo per season folder
@@ -925,7 +925,7 @@ def _stats_only(rows: List[List[str]], base_url: str, root: Path, write_nfos: bo
 
 class Plugin:
     name = "vod2strm"
-    version = "0.0.1"
+    version = "0.0.2"
     description = "Generate .strm and NFO files for Movies & Series from the Dispatcharr DB, with cleanup and CSV reports."
 
     fields = [


### PR DESCRIPTION
## Summary

- Bump version from 0.0.1 to 0.0.2 across all files
- Fix outdated endpoint documentation in plugin.py docstring
- Update version references in README.md

## Changes

1. **Version Bump (0.0.1 → 0.0.2)**
   - plugin.py header docstring (line 3)
   - Plugin class version attribute (line 928)
   - README.md versioning section (line 161)

2. **Documentation Fix**
   - Corrected endpoint format: `(movies|episodes)` → `(movie|episode)` to match actual implementation

## Rationale

This version bump reflects the critical fixes merged since 0.0.1:
- Plugin API signature update (Dispatcharr compatibility)
- Content filtering (active M3U relations only)
- URL endpoint fixes (singular not plural)
- Season NFO optimization (95% reduction in redundant writes)
- Celery fallback support

## Test Plan

- [x] Version string updated consistently across all files
- [x] Documentation accurately reflects current implementation