### PR TITLE
Lower max worker cap from 8 to 4 to prevent DB connection exhaustion

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -159,8 +159,9 @@ class AdaptiveThrottle:
     """
 
     def __init__(self, max_workers: int, enabled: bool = True):
-        # Hard cap at 8 to prevent DB connection exhaustion (Django creates 1 conn per thread)
-        self.max_workers = min(max_workers, 8)
+        # Hard cap at 4 to prevent DB connection exhaustion (Django creates 1 conn per thread)
+        # Even though workers do file I/O, accessing model attributes triggers DB connections
+        self.max_workers = min(max_workers, 4)
         self.enabled = enabled
         self.current_workers = self.max_workers
         self.write_times = []  # Rolling window of last N write times


### PR DESCRIPTION
## Problem

Even with the 8-worker cap from PR #16, PostgreSQL connections are still being exhausted:

```
FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute
```

Logs show the cap is working (`current workers: 8`), but 8 workers is still too many.

## Root Cause

Worker threads access Django model attributes, which triggers DB connection creation for each thread:
- 8 worker threads = 8 DB connections
- Main Django app = multiple connections
- Other processes = more connections
- **Total > PostgreSQL max_connections**

## Fix

Lower hard cap from **8 → 4 workers**

```python
# Before:
self.max_workers = min(max_workers, 8)

# After:
self.max_workers = min(max_workers, 4)
```

## Impact

- ✅ Stays within PostgreSQL connection pool limits
- ✅ Still provides good concurrency for file I/O
- ✅ Prevents connection exhaustion errors
- ⚠️ Slightly slower processing (8 → 4 workers)

## Files Changed

- `plugin.py`: 3 insertions, 2 deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Adjusted maximum concurrent operations threshold from 8 to 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->