### PR TITLE
Add workarounds for Dispatcharr series bugs (#556, #569)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,26 @@ name = re.sub(r'\s*\(\d{4}\)\s*$', '', name).strip()
 
 <!-- anchor: limitations -->
 
+### Dispatcharr Bug Workarounds
+
+The plugin includes defensive code to handle known Dispatcharr bugs:
+
+**Issue #556: Episodes Disappear After Sync**
+- **Problem**: Duplicate key constraint violation `vod_episode_series_id_season_number__73053ba7_uniq` causes episodes to be deleted during VOD refresh
+- **Workaround**:
+  - Catch duplicate key errors during `refresh_series_episodes()` and skip to next provider
+  - Validate episode still exists in DB before writing STRM file
+  - Log warnings when episodes vanish mid-generation
+  - Skip vanished episodes gracefully instead of crashing
+
+**Issue #569: Multiple M3UEpisodeRelation Records**
+- **Problem**: `get() returned more than one M3UEpisodeRelation` when same episode has multiple stream sources
+- **Workaround**:
+  - Use `.distinct()` on all episode queries to deduplicate
+  - Log warnings when duplicate relations detected
+  - Use highest priority provider when multiple relations exist
+  - Track relation count before/after distinct to detect duplicates
+
 ### Current Limitations
 - No incremental episode detection (requires manual re-run for new episodes)
 - No provider deduplication (if same content on multiple providers, generates multiple files)


### PR DESCRIPTION
## Summary

Adds defensive code to handle two known Dispatcharr bugs that affect series generation:

### Issue #556: Episodes Disappear After Sync
**Problem:** Duplicate key constraint violation on `(series_id, season_number, episode_number)` causes episodes to be deleted during VOD refresh.

**Workarounds:**
- Catch duplicate key errors during `refresh_series_episodes()` and skip to next provider
- Validate episode still exists in DB before writing STRM file
- Log warnings when episodes vanish mid-generation  
- Skip vanished episodes gracefully instead of crashing

### Issue #569: Multiple M3UEpisodeRelation Records
**Problem:** `get() returned more than one M3UEpisodeRelation` when same episode has multiple stream sources, causing internal server errors.

**Workarounds:**
- Use `.distinct()` on all episode queries to deduplicate
- Log warnings when duplicate relations detected
- Use highest priority provider when multiple relations exist
- Track relation count before/after distinct to detect duplicates

## Testing

- ✅ Syntax validated
- 🔄 Ready for live testing with series generation

## References

- [Dispatcharr Issue #556](https://github.com/Dispatcharr/Dispatcharr/issues/556)
- [Dispatcharr Issue #569](https://github.com/Dispatcharr/Dispatcharr/issues/569)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of episodes that disappear during synchronization operations.
  * Enhanced error handling during series refresh to gracefully manage duplicate records.
  * Better deduplication of redundant episode entries.

* **Documentation**
  * Added documented workarounds for known synchronization issues under Known Issues & Limitations.
  * Expanded Known Issues section with additional current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->