### PR TITLE
Bump version to 0.0.5 and fix signal handler docstrings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ A high-performance Dispatcharr plugin that exports VOD libraries (Movies and Ser
 - Scheduled runs via Celery beat
 - Auto-run after VOD refresh with debouncing
 
-**Current Version:** `0.0.4`
+**Current Version:** `0.0.5`
 
 ## Technology Stack
 

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,6 @@
 """
 vod2strm – Dispatcharr Plugin
-Version: 0.0.4
+Version: 0.0.5
 
 Spec:
 - ORM (in-process) with Celery background tasks (non-blocking UI).
@@ -1290,7 +1290,7 @@ def _stats_only(rows: List[List[str]], base_url: str, root: Path, write_nfos: bo
 
 class Plugin:
     name = "vod2strm"
-    version = "0.0.4"
+    version = "0.0.5"
     description = "Generate .strm and NFO files for Movies & Series from the Dispatcharr DB, with cleanup and CSV reports."
 
     fields = [
@@ -1672,7 +1672,7 @@ try:
     from django.db.models.signals import post_save, post_delete
     from django.dispatch import receiver
 
-    # Listen for Episode creation/updates (bulk_created signal doesn't fire for all cases)
+    # Listen for Episode creation (bulk_created signal doesn't fire for all cases)
     @receiver(post_save, sender=Episode)
     def on_episode_saved(sender, instance, created, **kwargs):
         """


### PR DESCRIPTION
Changes:
- Update version from 0.0.4 to 0.0.5 in plugin header and Plugin class
- Fix misleading docstrings in signal handlers:
  * Changed "episodes are created/updated" → "NEW episodes are created (not metadata updates)"
  * Changed "movies are created/updated" → "NEW movies are created (not metadata updates)"
- Update comment from "creation/updates" → "creation" to match code behavior
- Update CLAUDE.md current version to 0.0.5

Rationale:
The docstrings previously said "created/updated" but the code only checks `if created:`, meaning the handlers only fire when NEW content is added, not when metadata is updated. This clarification is important because:
- Prevents unnecessary regeneration when Dispatcharr updates ratings/descriptions
- Clarifies behavior when episodes are recreated after cleanup (they have created=True)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project version bumped to 0.0.5.

* **Documentation**
  * Clarified that Episode and Movie signals/listeners apply exclusively to new creations (not updates).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->