### PR TITLE
fix: Include stream_id parameter in .strm file URLs

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -176,14 +176,18 @@ def _get_movie_stream_id(movie: Movie) -> str | None:
 def _get_episode_stream_id(episode: Episode) -> str | None:
     """
     Get stream_id from the highest priority active M3U provider for an episode.
+    Filters by enabled categories to respect user's category preferences.
 
     Returns stream_id or None if no active provider found.
     """
     try:
-        # Get highest priority active relation
+        # Get highest priority active relation, filtering by enabled categories
+        # Same logic as _get_movie_stream_id to ensure consistency
         relation = M3UEpisodeRelation.objects.filter(
             episode_id=episode.id,
             m3u_account__is_active=True,
+        ).filter(
+            Q(category__isnull=True) | _enabled_category_subquery("m3u_account_id", "category_id")
         ).select_related('m3u_account').order_by(
             '-m3u_account__priority', 'id'
         ).first()


### PR DESCRIPTION
## Summary
Fix .strm file URL generation to include the `stream_id` query parameter, ensuring Dispatcharr uses the correct stream from the correct provider.

## Changes
- ✅ Add `_get_movie_stream_id()` helper to query M3UMovieRelation for highest priority provider
- ✅ Add `_get_episode_stream_id()` helper to query M3UEpisodeRelation for highest priority provider
- ✅ Update movie STRM URLs: `/proxy/vod/movie/{uuid}?stream_id={stream_id}`
- ✅ Update episode STRM URLs: `/proxy/vod/episode/{uuid}?stream_id={stream_id}`
- ✅ Import M3UEpisodeRelation model
- ✅ Bump version to 0.0.7

## Problem Solved
Without the `stream_id` parameter, Dispatcharr would fall back to auto-selecting a provider by priority, which could result in:
- Wrong provider selection when multiple providers have the same content
- Non-working streams being selected
- Inconsistent playback behavior

## How It Works
1. Query M3UMovieRelation/M3UEpisodeRelation tables for the movie/episode
2. Filter by active accounts and enabled categories
3. Sort by `m3u_account__priority` (descending) to get highest priority provider
4. Extract `stream_id` from the relation
5. Append `?stream_id={stream_id}` to the URL
6. If no stream_id found, fall back to UUID-only URL (Dispatcharr auto-selects)

## Testing
- ✅ Syntax validation passed
- Ready for testing with real provider data

## Release Notes
This is version **0.0.7** - a critical bug fix that improves playback reliability when multiple providers are configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream URLs now include stream identifier parameters when available for more accurate stream resolution.

* **Improvements**
  * Improved provider selection to prioritize active streams for both episodes and movies.
  * Manifest writing now caches and tracks URL changes so stream updates are detected reliably.

* **Chores**
  * Version bumped to 0.0.7.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->