### PR TITLE
Merge PR #38: Add content filtering by database ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ vod2strm transforms Dispatcharr's VOD database into media server-compatible `.st
 | **Auto-run after VOD Refresh** | Boolean | ☐ | Automatically generate files when Dispatcharr refreshes VOD content |
 | **Dry Run** | Boolean | ☐ | Simulate without writing (testing mode) |
 | **Robust debug logging** | Boolean | ☐ | Enable verbose logging to `/data/plugins/vod2strm/logs/` |
+| **Name Cleaning Regex** | Text | (empty) | Optional regex to strip patterns from names (e.g., `^(?:EN\|TOP)\s*-\s*`) |
+| **Content Filter: Movie IDs** | Text | (empty) | Comma-separated database IDs to include (e.g., `123,456`). Empty = generate all |
+| **Content Filter: Series IDs** | Text | (empty) | Comma-separated database IDs to include (e.g., `789,012`). Empty = generate all |
+
+## Content Filtering
+
+Filter specific movies or series by database ID instead of generating everything.
+
+### Finding Content IDs
+
+Content IDs are available in the Dispatcharr database. You can find them by:
+- Browsing your Dispatcharr VOD library UI (IDs visible in URLs or via browser dev tools)
+- Using database queries if you have direct access
+- Using the Dispatcharr API
+
+### Using Content Filters
+
+1. **Get the database IDs** for content you want to include
+2. **Add IDs to plugin settings**:
+   - Navigate to **Plugins → vod2strm**
+   - Enter comma-separated IDs in **Content Filter: Movie IDs**: `123,456,789`
+   - Enter comma-separated IDs in **Content Filter: Series IDs**: `321,654,987`
+3. **Generate .strm files**: Click **Generate All**
 
 ## Actions
 


### PR DESCRIPTION
Merges community contribution from @3E23 (PR #38) with current main.

## Status
✅ NO CONFLICTS - Git merged automatically

## New Features
- filter_movie_ids: Comma-separated database IDs
- filter_series_ids: Comma-separated database IDs
- Comprehensive README documentation

## Changes
- Modified _eligible_movie_queryset() to support ID filtering
- Modified _eligible_series_queryset() to support ID filtering
- Removed category filtering from episodes (inherit from series)
- Simplified episode query

## Credit
Original contribution by @3E23

Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added content filtering settings to filter movies and series by ID through the plugin configuration interface.

* **Documentation**
  * Expanded README with "Content Filtering" section, including instructions for locating content IDs, configuration format, and workflow examples for both movies and series.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->