### PR TITLE
feat: add tvshow.nfo generation for series

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,6 @@
 """
 vod2strm – Dispatcharr Plugin
-Version: 0.0.12
+Version: 0.0.13
 
 Spec:
 - ORM (in-process) with Celery background tasks (non-blocking UI).
@@ -1669,7 +1669,7 @@ def _stats_only(rows: List[List[str]], base_url: str, root: Path, write_nfos: bo
 
 class Plugin:
     name = "vod2strm"
-    version = "0.0.12"
+    version = "0.0.13"
     description = "Generate .strm and NFO files for Movies & Series from the Dispatcharr DB, with cleanup and CSV reports."
 
     fields = [


### PR DESCRIPTION
## Summary

Fixes #46

Adds series-level metadata file (`tvshow.nfo`) in the series root directory for Kodi/Plex/Jellyfin compatibility. Previously, only `season.nfo` and `episode.nfo` files were generated.

### What Was Missing

**Before:**
```
/data/STRM/TV/Series Name (2020)/
├── Season 01/
│   ├── season.nfo           ✅ Had this
│   ├── S01E01.nfo           ✅ Had this
│   └── S01E01 - Title.strm  ✅ Had this
└── tvshow.nfo               ❌ MISSING!
```

**Now:**
```
/data/STRM/TV/Series Name (2020)/
├── tvshow.nfo               ✅ NEW!
├── Season 01/
│   ├── season.nfo
│   ├── S01E01.nfo
│   └── S01E01 - Title.strm
```

## Changes

- **plugin.py:662-691** - Add `_nfo_tvshow()` function to generate series metadata XML
- **plugin.py:1368** - Add `written_tvshows` tracking set (similar to `written_seasons`)
- **plugin.py:849-870** - Write tvshow.nfo once per series when processing first episode
- **plugin.py:724-727** - Update `_compare_tree_quick()` to validate tvshow.nfo exists
- Add `tvshow_nfo` row type to CSV reports

## tvshow.nfo Content

The tvshow.nfo file contains:
- Series title (with cleaned name support)
- Plot/description
- Year
- Rating
- Genre
- TMDB ID
- IMDB ID
- Series logo/poster

**Example:**
```xml
<tvshow>
  <title>Breaking Bad</title>
  <plot>A high school chemistry teacher diagnosed with...</plot>
  <year>2008</year>
  <rating>9.5</rating>
  <genre>Crime, Drama, Thriller</genre>
  <uniqueid type="tmdb">1396</uniqueid>
  <uniqueid type="imdb">tt0903747</uniqueid>
  <thumb>https://image.tmdb.org/t/p/original/poster.jpg</thumb>
</tvshow>
```

## Test Plan

- [ ] Plugin loads without errors
- [ ] Generate series with "Write NFO files" enabled
- [ ] Verify `tvshow.nfo` appears in series root directory
- [ ] Verify tvshow.nfo contains correct series metadata
- [ ] Verify season.nfo and episode.nfo still generate correctly
- [ ] Verify CSV report includes tvshow_nfo rows
- [ ] Test with name_clean_regex setting
- [ ] Verify quick tree check validates tvshow.nfo existence
- [ ] Test that media centers (Plex/Jellyfin/Kodi) properly read the metadata

## Implementation Details

**Thread Safety:** Uses the existing `written_tvshows` set with lock protection to ensure tvshow.nfo is written only once per series, even in concurrent processing.

**Performance:** Write time is tracked for adaptive throttling, consistent with other NFO file operations.

**Compatibility:** Follows the same XML structure and patterns as `_nfo_movie()`, ensuring consistency across the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic generation of series-level TV metadata files (tvshow.nfo) for media collections.

* **Refactor**
  * Ensures each series-level metadata file is written only once during processing to avoid duplicates.
  * File-comparison logic now accounts for series-level metadata when metadata output is enabled.

* **Cleanup**
  * Orphan series metadata files are pruned when no episode files remain; cleanup reports updated.

* **Chores**
  * Plugin version updated to 0.0.13

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->