### PR TITLE
fix: add missing continue after series refresh failure to prevent hang

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1291,7 +1291,11 @@ def _generate_series(rows: List[List[str]], base_url: str, root: Path, write_nfo
                     # Episodes were fetched, recount (no sleep needed - synchronous call)
                     expected = _series_expected_count(s.id)
                 else:
+                    # Skip immediately to avoid unnecessary database queries for series we know have no episodes
                     LOGGER.debug("Could not fetch episodes for series id=%s; skipping.", s.id)
+                    with lock:
+                        rows.append(["series", s.name or "", "", "", getattr(s, "year", ""), str(s.uuid), str(series_folder), "", "skipped", "refresh_failed"])
+                    continue
 
             if expected > 0 and _compare_tree_quick(series_folder, expected, write_nfos):
                 with lock:


### PR DESCRIPTION
When episode refresh fails for a series, the code logged "skipping" but didn't actually skip. This caused unnecessary database queries for each failed series, significantly slowing down generation when many series fail to refresh (e.g., when provider returns episodes in wrong format).

The fix:
- Adds `continue` statement after logging refresh failure
- Records "refresh_failed" in CSV report for visibility
- Avoids 2 unnecessary DB queries per failed series

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for series refresh failures: Series that fail to refresh and contain no episodes are now explicitly reported as "skipped" with detailed failure reason information, providing better transparency into refresh operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->